### PR TITLE
Bug 1145836 - Rename mcMerge to Bugherder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
-mcMerge is a tool for marking bugs post-merge.
+Bugherder is a tool for marking bugs post-merge.
 
 NOTES ON TESTING
 ----------------
-Adding "?debug=1" shows how all changesets were identified, and shows what changesets mcMerge decided were affected by a backout.
+Adding "?debug=1" shows how all changesets were identified, and shows what changesets Bugherder decided were affected by a backout.
 
 Adding "?remap=1" allows you to divert output to the bzapi sandbox bugzilla at [landfill.bugzilla.org](https://://landfill.bugzilla.org/bzapi_sandbox/).
 If you use this option, you will be presented with a table of all the bugs associated with changesets. You can then enter a bug number from bzapi that output will be sent to. You don't need to enter a new bug number for every single bug shown, but only those you do enter will be transmitted, other bugs will be ignored.
 
-mcMerge will not check the existence of any bugs you enter - be careful! Each bug number entered must be unique - that **will** be checked, as apparently I can't follow my own instructions. You will probably want to review the pushlog - if the push for the only bug you entered was backed out, then nothing will be sent.
+Bugherder will not check the existence of any bugs you enter - be careful! Each bug number entered must be unique - that **will** be checked, as apparently I can't follow my own instructions. You will probably want to review the pushlog - if the push for the only bug you entered was backed out, then nothing will be sent.
 
 When testing target milestone setting, the equivalent bug in landfill must be filed in the *mcMerge Test Product* product, or the submission will fail.
 
 There are various checkbox options at the bottom of the screen:
 * an option to add [inbound] to some random bug whiteboards, to allow you to test it's removal on submission
 * an option to add checkin-needed to some random bug whiteboards, to allow you to test it's removal on submission. Be careful of bugs with additional keywords - if they are not defined on landfill (and they probably won't be), the submission will fail
-* an option to throw up an alert - hacky, I know - partway through the submission process, to allow you to jump over to the landfill bug, and mid-air mcMerge
+* an option to throw up an alert - hacky, I know - partway through the submission process, to allow you to jump over to the landfill bug, and mid-air Bugherder
 * a useful option to ignore the real bug status, and set it to NEW, as you will likely be working with historic pushlogs when testing
 
 If you do not enter any diversion bugs on the remap page, you will return to live mode, with changes going to [bugzilla.mozilla.org](https://bugzilla.mozilla.org/).
@@ -22,7 +22,7 @@ If you do not enter any diversion bugs on the remap page, you will return to liv
 
 STANDING ON THE SHOULDERS OF GIANTS
 -----------------------------------
-mcMerge uses the following third-party projects:
+Bugherder uses the following third-party projects:
 
 * bz.js by Heather Arthur - [https://github.com/harthur/bz.js](https://github.com/harthur/bz.js)
 * jQuery - [http://jquery.com/](http://jquery.com)

--- a/css/style.css
+++ b/css/style.css
@@ -336,7 +336,7 @@ div.ctr {
   float: left;
 }
 
-#mcmerge-revision {
+#bugherder-revision {
   text-align: right;
   float: right;
   display: none;
@@ -352,7 +352,7 @@ div.ctr {
 }
 
 @-moz-document url-prefix(https://mcmerge.paas.allizom.org/) {
-  #mcmerge-revision {
+  #bugherder-revision {
     display: inline !important;
   }
 }

--- a/index.html
+++ b/index.html
@@ -19,13 +19,13 @@
     <script type="text/javascript" src="js/ConfigurationData.js"></script>
     <script type="text/javascript" src="js/BugData.js"></script>
     <script type="text/javascript" src="js/Remapper.js"></script>
-    <script type="text/javascript" src="js/mcMerge.js"></script>
-    <title>mcMerge</title>
+    <script type="text/javascript" src="js/bugherder.js"></script>
+    <title>Bugherder</title>
   </head>
   <body>
     <div class="hideAll" id="opaque"></div>
     <div class="ctr">
-      <h1 id="title">mcMerge</h1>
+      <h1 id="title">Bugherder</h1>
       <h4>A tool to help with post-merge Bugzilla administrivia. <a href="http://www.graememcc.co.uk/tag/m-cmerge/">Learn more.</a></h4>
       <div class="hiddenContent hideAll" id="errors">
         <span id="errorText"></span>
@@ -157,9 +157,9 @@
 
     <div id="footer">
       <div id="source-link">
-        <a href="https://github.com/mozilla/mcMerge">mcMerge Source</a>
+        <a href="https://github.com/mozilla/Bugherder">Bugherder Source</a>
       </div>
-      <div id="mcmerge-revision">
+      <div id="bugherder-revision">
         <a href="deploy.txt">Deployed revision</a>
       </div>
     </div>

--- a/js/BugData.js
+++ b/js/BugData.js
@@ -31,10 +31,10 @@ var BugData = {
 
 
   _realLoad: function BD_realLoad(bugs) {
-    if (mcMerge.trackingFlag)
-      this.trackingFlag = 'cf_' + mcMerge.trackingFlag;
-    if (mcMerge.statusFlag)
-      this.statusFlag = 'cf_' + mcMerge.statusFlag;
+    if (bugherder.trackingFlag)
+      this.trackingFlag = 'cf_' + bugherder.trackingFlag;
+    if (bugherder.statusFlag)
+      this.statusFlag = 'cf_' + bugherder.statusFlag;
 
     var includeFields = this.fields;
     if (this.checkComments)

--- a/js/Remapper.js
+++ b/js/Remapper.js
@@ -176,7 +176,7 @@ var Remapper = {
      remaps.midair = false;
 
     UI.clearErrorMessage();
-    mcMerge.onRemap(remaps);
+    bugherder.onRemap(remaps);
   },
 
 

--- a/js/Step.js
+++ b/js/Step.js
@@ -159,7 +159,7 @@ Step.prototype.createBug = function Step_createBug(bugID, info) {
 
     // Set status flag if appropriate
     if (info.canSetStatus && info.shouldSetStatus) {
-      var fieldName = 'cf_' + mcMerge.statusFlag;
+      var fieldName = 'cf_' + bugherder.statusFlag;
       bug[fieldName] = 'fixed';
     }
 
@@ -223,7 +223,7 @@ Step.prototype.onSubmitError = function Step_onSubmitError(where, msg, i) {
     // - a tester remapped to a non-existant bug on landfill, (they should know better :))
     // If we've failed trying to get the time/token on our very first bug, let's just put it
     //   down to username/password, and abandon this submit attempt
-    // If we failed in the i-1th bug too, again abandon all hope. (Did you change your password while mcMerge was working?!?)
+    // If we failed in the i-1th bug too, again abandon all hope. (Did you change your password while bugherder was working?!?)
     // Else, we'll note this one failed and try the next. If we carry on without further failure, then this was a
     //  security bug that wasn't one before
     if (i == 0 || this.retries[this.retries.length-1] == i - 1) {
@@ -418,10 +418,10 @@ Step.prototype.postSubmit = function Step_postSubmit(i) {
   }
 
   // Disallow setting status- if we just sent it
-  if ('cf_' + mcMerge.statusFlag in sent) {
+  if ('cf_' + bugherder.statusFlag in sent) {
     info.canSetStatus = false;
     info.shouldSetStatus = false;
-    BugData.bugs[bugID].statusFlag = sent['cf_' + mcMerge.statusFlag];
+    BugData.bugs[bugID].statusFlag = sent['cf_' + bugherder.statusFlag];
   }
 
   this.continueSubmit(i);
@@ -947,17 +947,17 @@ Step.prototype.constructTextFor = function Step_constructTextFor(arr, postText, 
 // Calls out various interesting properties of the attached bugs
 //   - "multi" bugs (where a bug is associated with multiple changesets
 //   - "leave open" bugs (where the assignee doesn't want the bug resolved
-//   - "security" bugs (bugs mcMerge couldn't access)
+//   - "security" bugs (bugs bugherder couldn't access)
 //   - "has milestone" bugs (bugs that can be resolved, but already had a milestone)
 Step.prototype.getAdditionalHelpText = function Step_getAdditionalHelpText() {
   var text = '';
 
   var multiPost = ' associated with multiple changesets: the individual comments will be coalesced into a single comment.';
   var leaveOpenPost = ' "leave open" in the whiteboard, so the resolve flag has not been set.';
-  var securityPost = ' restricted - mcMerge was unable to load the relevant information from Bugzilla.';
+  var securityPost = ' restricted - bugherder was unable to load the relevant information from Bugzilla.';
   var milestonePost = ' a milestone set. You may wish to check it is correct before submitting.';
   var alreadyCommentPost = ' to have already been commented with the correct changeset URL, so commenting there has been disabled.';
-  var statusChangePost = ' tracked or uplifted and will have ' + mcMerge.statusFlag + ' set to "fixed".';
+  var statusChangePost = ' tracked or uplifted and will have ' + bugherder.statusFlag + ' set to "fixed".';
 
   var hashave = {singular: 'has', plural: 'have'};
   var appearTo = {singular: 'appears', plural: 'appear'};
@@ -1027,7 +1027,7 @@ Step.prototype.getHelpText = function Step_getHelpText() {
   helpText += this.getAdditionalHelpText();
 
   if (this.statusChangeBugs.length > 0 && Config.treeInfo[Config.treeName].unconditionalFlag)
-    helpText += '<br>- Submitted bugs will have ' + mcMerge.statusFlag + ' set to "fixed"';
+    helpText += '<br>- Submitted bugs will have ' + bugherder.statusFlag + ' set to "fixed"';
 
   if (Step.remaps && 'items' in Step.remaps && Step.remaps.items > 0)
     helpText += '<br><strong>Note: You are in debug mode. Only remap bugs will be submitted, and will be submitted to landfill.bugzilla.org!</strong>';

--- a/js/bugherder.js
+++ b/js/bugherder.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var mcMerge = {
+var bugherder = {
   debug: false,
   expand: false,
   remap: false,
@@ -21,7 +21,7 @@ var mcMerge = {
     var self = this;
     $(window).load(function onDocReady() {
       if (Config.inMaintenanceMode) {
-        $('#errorText').text('mcMerge is down for maintenance!');
+        $('#errorText').text('bugherder is down for maintenance!');
         UI.show('errors');
         return;
       }
@@ -29,7 +29,7 @@ var mcMerge = {
       if (Config.supportsHistory) {
         // Set the popstate handler on a timeout, to avoid the inital load popstate in Webkit
         window.setTimeout(function mcM_onLoadTimeout() {
-          $(window).on('popstate', {mcMerge: self}, function mcM_InitPopstate(e) {
+          $(window).on('popstate', {bugherder: self}, function mcM_InitPopstate(e) {
            self.parseQuery(e);
           });
         }, 1);
@@ -53,7 +53,7 @@ var mcMerge = {
 
     var self = this;
 
-    document.title = 'mcMerge';
+    document.title = 'bugherder';
 
     var formListener = function mcM_acquireListener(e) {
       self.validateForm(e);
@@ -334,7 +334,7 @@ var mcMerge = {
       return;
     }
 
-    document.title = 'mcMerge (changeset: ' + cset + ')';
+    document.title = 'bugherder (changeset: ' + cset + ')';
     this.loading = 'cset';
     UI.showLoadingMessage('Loading pushlog data...');
 
@@ -456,7 +456,7 @@ var mcMerge = {
     if (!event)
       self = this;
     else
-      self = event.data.mcMerge;
+      self = event.data.bugherder;
 
     var query = document.location.search;
     if (query) {
@@ -552,4 +552,4 @@ var mcMerge = {
     }
   }
 };
-mcMerge.init();
+bugherder.init();

--- a/stackato.yml
+++ b/stackato.yml
@@ -9,8 +9,8 @@
 #   is running an older v2.x Stackato release.
 # * The cron that we use to update the repo only runs on instance #0, so we limit
 #   the number of instances to one, since any others wouldn't self-update.
-# * We set app-dir to be a subdirectory of the mcMerge repo, to ensure we only
-#   upload 'Staticfile' and not the whole mcMerge repo.
+# * We set app-dir to be a subdirectory of the Bugherder repo, to ensure we only
+#   upload 'Staticfile' and not the whole Bugherder repo.
 # * The buildpack's staging step copies the project root to public/ in its entirety,
 #   but we don't want .git to be served by nginx, so we delete it post staging.
 # * The buildpack we're using auto-redirects http to https if FORCE_HTTPS is defined.
@@ -18,12 +18,13 @@
 # To deploy this to Mozilla's Stackato instance, follow the generic client setup
 # steps on Mana, and then |stackato push --no-prompt| from the root of the repo.
 # However once it is deployed, it should need to further intervention, since it
-# will auto-update from the mcMerge repo every 5 minutes, storing the status of
+# will auto-update from the Bugherder repo every 5 minutes, storing the status of
 # the update at: <site>/deploy.txt
 
-name: mcmerge
+name: bugherder
 url:
-  - mcmerge.paas.allizom.org
+  - bugherder.paas.allizom.org
+  - bugherder.mozilla.org
 instances: 1
 mem: 64M
 framework:
@@ -34,7 +35,7 @@ env:
 app-dir: deployment
 hooks:
   pre-staging:
-    - git clone --depth 1 https://github.com/mozilla/mcMerge.git src
+    - git clone --depth 1 https://github.com/mozilla/Bugherder.git src
   post-staging:
     - rm -rf public/.git
     - echo "Cron not yet run on this instance!" > public/deploy.txt


### PR DESCRIPTION
This renames most uses of the string "mcMerge" with "Bugherder" in the repository. It leaves most of stackato.yml untouched as the deployed location has not yet been updated.