### PR TITLE
Bug 1154718 - Improve release branch flag handling

### DIFF
--- a/js/Config.js
+++ b/js/Config.js
@@ -49,7 +49,6 @@ var Config = {
     "thunderbird-beta": "comm-beta",
     "thunderbird-esr38": "comm-esr38",
     "thunderbird-esr31": "comm-esr31",
-    "thunderbird-esr24": "comm-esr24",
   },
 
   treeInfo: {

--- a/js/Config.js
+++ b/js/Config.js
@@ -47,6 +47,7 @@ var Config = {
     "thunderbird-trunk": "comm-central",
     "thunderbird-aurora": "comm-aurora",
     "thunderbird-beta": "comm-beta",
+    "thunderbird-esr38": "comm-esr38",
     "thunderbird-esr31": "comm-esr31",
     "thunderbird-esr24": "comm-esr24",
   },
@@ -93,6 +94,12 @@ var Config = {
       trackedTree: true,
       unconditionalFlag: false,
       synonyms: ["esr31", "releases/mozilla-esr31", "mozilla-esr31"]
+    },
+    "mozilla-esr38": {
+      repo: "releases/mozilla-esr38",
+      trackedTree: true,
+      unconditionalFlag: false,
+      synonyms: ["esr38", "releases/mozilla-esr38", "mozilla-esr38"]
     },
     "mozilla-b2g34-v2.1": {
       repo: "releases/mozilla-b2g34_v2_1",
@@ -238,6 +245,12 @@ var Config = {
       unconditionalFlag: false,
       trackedTree: true,
       synonyms: ["releases/comm-esr31", "comm-esr31"]
+    },
+    "comm-esr38": {
+      repo: "releases/comm-esr38",
+      unconditionalFlag: false,
+      trackedTree: true,
+      synonyms: ["releases/comm-esr38", "comm-esr38"]
     }
   }
 };

--- a/js/Config.js
+++ b/js/Config.js
@@ -101,19 +101,25 @@ var Config = {
       unconditionalFlag: false,
       synonyms: ["esr38", "releases/mozilla-esr38", "mozilla-esr38"]
     },
-    "mozilla-b2g34-v2.1": {
+    "mozilla-b2g37_v2_2": {
+      repo: "releases/mozilla-b2g37_v2_2",
+      unconditionalFlag: true,
+      trackedTree: true,
+      synonyms: ["b2g37", "mozilla-b2g37", "mozilla-b2g37_v2_2", "v2.2"]
+    },
+    "mozilla-b2g34-v2_1": {
       repo: "releases/mozilla-b2g34_v2_1",
       unconditionalFlag: true,
       trackedTree: true,
       synonyms: ["b2g34", "mozilla-b2g34", "mozilla-b2g34_v2_1", "v2.1"]
     },
-    "mozilla-b2g32-v2.0": {
+    "mozilla-b2g32-v2_0": {
       repo: "releases/mozilla-b2g32_v2_0",
       unconditionalFlag: true,
       trackedTree: true,
       synonyms: ["b2g32", "mozilla-b2g32", "mozilla-b2g32_v2_0", "v2.0"]
     },
-    "mozilla-b2g30-v1.4": {
+    "mozilla-b2g30-v1_4": {
       repo: "releases/mozilla-b2g30_v1_4",
       unconditionalFlag: true,
       trackedTree: true,

--- a/js/FlagLoader.js
+++ b/js/FlagLoader.js
@@ -3,6 +3,16 @@
 var FlagLoader = {
 
   init: function FL_init(cset, tree, loadCallback, errorCallback) {
+    // Bug 1159415: Short term tweak to set the firefox38.0.5 flags
+    var thisDate = new Date();
+    var betaDate = new Date(2015, 4, 11);
+    var releaseDate = new Date(2015, 5, 29);
+    if ((thisDate < betaDate && tree == 'mozilla-beta') ||
+        (betaDate < thisDate && thisDate < releaseDate && tree == 'mozilla-release')) {
+      this.generateFlags('firefox38.0.5');
+      loadCallback(flags);
+      return;
+    }
     // The version for some repositories is a constant, since they're release branches.
     // We can infer their version from the repo name to avoid querying the repo.
     var esrVersion = /-esr(\d+)$/.exec(tree);

--- a/js/FlagLoader.js
+++ b/js/FlagLoader.js
@@ -7,7 +7,7 @@ var FlagLoader = {
     // We can infer their version from the repo name to avoid querying the repo.
     var esrVersion = /-esr(\d+)$/.exec(tree);
     if (esrVersion) {
-      var esrName = 'esr';
+      var esrName = 'firefox_esr';
       if (tree.indexOf('comm') != -1) {
         esrName = 'thunderbird_esr';
       }


### PR DESCRIPTION
This fixes various issues with setting release branch flags:

First, this fixes setting ESR status/tracking flags so they actually get set.

Second, this adds some new code to deal with setting the firefox38.0.5 flags for the next couple of months. (We'll want to revert this once 39 ships, though I think the Date checks I put in should make things revert to normal behavior once it ships.)

Next, it adds support for the esr38 repos that are in the process of being added.

Finally, it should hopefully make Bugherder able to process b2g release branches. This doesn't fix setting b2g release branch flags yet, but I might wait for some other Bugherder changes (being able to manually set flags, etc) before I deal with them.