### PR TITLE
Fix 38.0.5 flags, hopefully

### DIFF
--- a/js/FlagLoader.js
+++ b/js/FlagLoader.js
@@ -9,7 +9,7 @@ var FlagLoader = {
     var releaseDate = new Date(2015, 5, 29);
     if ((thisDate < betaDate && tree == 'mozilla-beta') ||
         (betaDate < thisDate && thisDate < releaseDate && tree == 'mozilla-release')) {
-      var flags = this.generateFlags('firefox38.0.5');
+      var flags = this.generateFlags('firefox38_0_5');
       loadCallback(flags);
       return;
     }


### PR DESCRIPTION
Pretty sure we need to replace the '.'s with '_'s in the flag name for the API call.