### PR TITLE
Bug 1160697 - Try to get b2g flags working

### DIFF
--- a/js/Config.js
+++ b/js/Config.js
@@ -106,19 +106,19 @@ var Config = {
       trackedTree: true,
       synonyms: ["b2g37", "mozilla-b2g37", "mozilla-b2g37_v2_2", "v2.2"]
     },
-    "mozilla-b2g34-v2_1": {
+    "mozilla-b2g34_v2_1": {
       repo: "releases/mozilla-b2g34_v2_1",
       unconditionalFlag: true,
       trackedTree: true,
       synonyms: ["b2g34", "mozilla-b2g34", "mozilla-b2g34_v2_1", "v2.1"]
     },
-    "mozilla-b2g32-v2_0": {
+    "mozilla-b2g32_v2_0": {
       repo: "releases/mozilla-b2g32_v2_0",
       unconditionalFlag: true,
       trackedTree: true,
       synonyms: ["b2g32", "mozilla-b2g32", "mozilla-b2g32_v2_0", "v2.0"]
     },
-    "mozilla-b2g30-v1_4": {
+    "mozilla-b2g30_v1_4": {
       repo: "releases/mozilla-b2g30_v1_4",
       unconditionalFlag: true,
       trackedTree: true,

--- a/js/FlagLoader.js
+++ b/js/FlagLoader.js
@@ -26,9 +26,27 @@ var FlagLoader = {
       return;
     }
     if (tree.indexOf('mozilla-b2g') != -1) {
-      // TODO: B2G repos use B2G version numbers, which are not yet supported.
-      errorCallback(null, 'unknown tree');
-      loadCallback({});
+      // Hardcode some b2g release branch flags
+      var flags;
+      switch(tree) {
+        case "mozilla-b2g30_v1_4":
+          flags = this.generateFlags("b2g_1_4");
+          break;
+        case "mozilla-b2g32_v2_0":
+          flags = this.generateFlags("b2g_2_0");
+          break;
+        case "mozilla-b2g34_v2_1":
+          flags = this.generateFlags("b2g_2_1");
+          break;
+        case "mozilla-b2g37_v2_2":
+          flags = this.generateFlags("b2g_2_2");
+          break;
+        default:
+          errorCallback(null, 'unknown tree');
+          flags = {};
+          return;
+      }
+      loadCallback(flags);
       return;
     }
     var treeInfo = Config.treeInfo[tree];
@@ -62,7 +80,12 @@ var FlagLoader = {
   },
 
   generateFlags: function FL_generateFlags(flagSuffix) {
-    return {'tracking': 'tracking_' + flagSuffix,
-            'status': 'status_' + flagSuffix};
+    // B2G doesn't use tracking flags, only status
+    if(flagSuffix.indexOf('b2g_') != -1) {
+      return {'status': 'status_' + flagSuffix};
+    } else {
+      return {'tracking': 'tracking_' + flagSuffix,
+              'status': 'status_' + flagSuffix};
+    }
   }
 };

--- a/js/bugherder.js
+++ b/js/bugherder.js
@@ -208,9 +208,12 @@ var bugherder = {
   // Callback following load of tracking flag names. Kicks off loading of configuration data from BZ
   onFlagsLoad: function mcM_onFlagLoad(flagData) {
     UI.hideLoadingMessage();
-    this.trackingFlag = flagData.tracking;
-    this.statusFlag = flagData.status;
-
+    if(flagData.tracking) {
+      this.trackingFlag = flagData.tracking;
+    }
+    if(flagData.status) {
+      this.statusFlag = flagData.status;
+    }
     this.loadConfigurationFromBZ();
   },
 


### PR DESCRIPTION
I believe this will work, and should be obvious and easy enough to add/remove future b2g release versions as needed.

I don't know if that last chunk is actually needed, but I don't believe the tracking_ flags exist for b2g bugs, and I don't know how well Bugzilla's API deals with non-existent flags being messed with, so I just don't generate them at all.