### PR TITLE
Bug 1166865 - Make status flags get set when they were previously set to '?'

### DIFF
--- a/js/Step.js
+++ b/js/Step.js
@@ -561,7 +561,7 @@ Step.prototype.attachBugToCset = function Step_attachBugToCset(index, bugID) {
     }
 
     // Release-tracking: determine if status-[tree]N can be set
-    if (bug && (bug.statusFlag == '---' || bug.statusFlag == 'affected')) {
+    if (bug && (bug.statusFlag == '---' || bug.statusFlag == 'affected' || bug.statusFlag == '?')) {
       if ((bug.isTracked || bug.statusFlag == "affected") && (isMC || Config.treeName == 'comm-central'))
         this.bugInfo[bugID].canSetStatus = this.bugInfo[bugID].canResolve;
       else if (Config.treeInfo[Config.treeName].trackedTree)


### PR DESCRIPTION
I think this is all that's needed.