### PR TITLE
Add some tests for FlagLoader.js

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -15,8 +15,8 @@ module.exports = function(config) {
 
     // list of files / patterns to load in the browser
     files: [
-      'js/BugData.js',
-      'js/FlagLoader.js',
+      'thirdparty/*/*.js',
+      'js/*.js',
       'test/*Spec.js'
     ],
 

--- a/test/SpecRunner.html
+++ b/test/SpecRunner.html
@@ -12,7 +12,22 @@
     <script src="../node_modules/jasmine-core/lib/jasmine-core/boot.js"></script>
 
     <!-- include the library you want to test here... -->
-    <script src="../js/FlagLoader.js"></script>
+    <script type="text/javascript" src="../thirdparty/jquery/jquery-1.7.2.min.js"></script>
+    <script type="text/javascript" src="../thirdparty/bzjs/bz-0.3.0.js"></script>
+    <script type="text/javascript" src="../js/Utils.js"></script>
+    <script type="text/javascript" src="../js/Config.js"></script>
+    <script type="text/javascript" src="../js/Step.js"></script>
+    <script type="text/javascript" src="../js/UI.js"></script>
+    <script type="text/javascript" src="../js/DebugUI.js"></script>
+    <script type="text/javascript" src="../js/ViewerController.js"></script>
+    <script type="text/javascript" src="../js/Viewer.js"></script>
+    <script type="text/javascript" src="../js/Summary.js"></script>
+    <script type="text/javascript" src="../js/PushData.js"></script>
+    <script type="text/javascript" src="../js/FlagLoader.js"></script>
+    <script type="text/javascript" src="../js/ConfigurationData.js"></script>
+    <script type="text/javascript" src="../js/BugData.js"></script>
+    <script type="text/javascript" src="../js/Remapper.js"></script>
+    <script type="text/javascript" src="../js/bugherder.js"></script>
 
     <!-- include your test files here... -->
     <script src="mySpec.js"></script>

--- a/test/mySpec.js
+++ b/test/mySpec.js
@@ -1,4 +1,6 @@
-describe("A suite", function() {
+console.log("Starting mySpec.js tests");
+
+describe("A Hello World suite", function() {
   it("contains spec with an expectation", function() {
     expect(true).toBe(true);
   });
@@ -6,13 +8,188 @@ describe("A suite", function() {
   it("contains spec with a false expectation", function() {
     expect(true).not.toBe(false);
   });
+});
 
-  it("should test FlagLoader.js maybe 4realz", function() {
-    var results = {
+describe("A FlagLoader suite", function() {
+  it("should generate flags for 'firefox39'", function() {
+    console.log("starting firefox39 test");
+    results = {
       'tracking': 'tracking_firefox39',
       'status': 'status_firefox39'
     }
     expect(FlagLoader.generateFlags("firefox39")).toEqual(results);
   });
+
+  it("should generate flags for 'b2g_2_0'", function() {
+    console.log("starting b2g_2_0 test");
+
+    results = {
+      'status': 'status_b2g_2_0'
+    }
+
+    expect(FlagLoader.generateFlags("b2g_2_0")).toEqual(results);
+  });
+
+  it("should init properly for b2g32", function() {
+    console.log("starting b2g32 test");
+
+    results = {
+      status: 'status_b2g_2_0'
+    }
+
+    var loadCallback = function loadCallback1(flagData) {
+     console.log(flagData, results);
+     expect(flagData).toEqual(results);
+    };
+
+    var errorCallback = function errorCallback(jqResponse, textStatus, errorThrown) {};
+
+    FlagLoader.init("3ae7fd12f53f", "mozilla-b2g32_v2_0", loadCallback, errorCallback);
+  });
+
+  it("should init properly for b2g32m", function() {
+    console.log("starting b2g32m test");
+
+    results = {
+      status: 'status_b2g_2_0m'
+    }
+
+    var loadCallback = function loadCallback1(flagData) {
+     console.log(flagData, results);
+     expect(flagData).toEqual(results);
+    };
+
+    var errorCallback = function errorCallback(jqResponse, textStatus, errorThrown) {};
+
+    FlagLoader.init("5ee3a69cb111", "mozilla-b2g32_v2_0m", loadCallback, errorCallback);
+  });
+
+
+  it("should init properly for b2g34", function() {
+    console.log("starting b2g34 test");
+
+    results = {
+      status: 'status_b2g_2_1'
+    }
+
+    var loadCallback = function loadCallback1(flagData) {
+     console.log(flagData, results);
+     expect(flagData).toEqual(results);
+    };
+
+    var errorCallback = function errorCallback(jqResponse, textStatus, errorThrown) {};
+
+    FlagLoader.init("d1ed7de67f5a", "mozilla-b2g34_v2_1", loadCallback, errorCallback);
+  });
+
+
+  it("should init properly for b2g34s", function() {
+    console.log("starting b2g34s test");
+
+    results = {
+      status: 'status_b2g_2_1_s'
+    }
+
+    var loadCallback = function loadCallback1(flagData) {
+     console.log(flagData, results);
+     expect(flagData).toEqual(results);
+    };
+
+    var errorCallback = function errorCallback(jqResponse, textStatus, errorThrown) {};
+
+    FlagLoader.init("2ef755f395fd", "mozilla-b2g34_v2_1s", loadCallback, errorCallback);
+  });
+
+
+  it("should init properly for b2g37", function() {
+    console.log("starting b2g37 test");
+
+    results = {
+      status: 'status_b2g_2_2'
+    }
+
+    var loadCallback = function loadCallback1(flagData) {
+     console.log(flagData, results);
+     expect(flagData).toEqual(results);
+    };
+
+    var errorCallback = function errorCallback(jqResponse, textStatus, errorThrown) {};
+
+    FlagLoader.init("f15bd4bdff6e", "mozilla-b2g37_v2_2", loadCallback, errorCallback);
+  });
+
+
+  it("should init properly for b2g37r", function() {
+    console.log("starting b2g37r test");
+
+    results = {
+      status: 'status_b2g_2_2r'
+    }
+
+    var loadCallback = function loadCallback1(flagData) {
+     console.log(flagData, results);
+     expect(flagData).toEqual(results);
+    };
+
+    var errorCallback = function errorCallback(jqResponse, textStatus, errorThrown) {};
+
+    FlagLoader.init("94737c119e75", "mozilla-b2g37_v2_2r", loadCallback, errorCallback);
+  });
+
+  it("should init properly for esr38", function() {
+    console.log("starting esr38 test");
+
+    results = {
+      tracking: 'tracking_firefox_esr38',
+      status: 'status_firefox_esr38'
+    }
+
+    var loadCallback = function loadCallback(flagData) {
+     console.log(flagData, results);
+     expect(flagData).toEqual(results);
+    };
+
+    var errorCallback = function errorCallback(jqResponse, textStatus, errorThrown) {};
+
+    FlagLoader.init("3ae7fd12f53f", "mozilla-esr38", loadCallback, errorCallback);
+  });
+
+  it("should init properly for mozilla-central", function(done) {
+    console.log("starting mozilla-central test");
+
+    results = {
+      tracking: 'tracking_firefox42',
+      status: 'status_firefox42'
+    }
+
+    var loadCallback = function loadCallback(flagData) {
+     console.log(flagData, results);
+     expect(flagData).toEqual(results);
+     done();
+    };
+
+    var errorCallback = function errorCallback(jqResponse, textStatus, errorThrown) {};
+
+    FlagLoader.init("1d4f44ee5166", "mozilla-central", loadCallback, errorCallback);
+  }, 10000);
+
+  it("should init properly for mozilla-aurora", function(done) {
+    console.log("starting mozilla-aurora test");
+
+    results = {
+      tracking: 'tracking_firefox41',
+      status: 'status_firefox41'
+    }
+
+    var loadCallback = function loadCallback(flagData) {
+     console.log(flagData, results);
+     expect(flagData).toEqual(results);
+     done();
+    };
+
+    var errorCallback = function errorCallback(jqResponse, textStatus, errorThrown) {};
+
+    FlagLoader.init("510a87909ff5", "mozilla-aurora", loadCallback, errorCallback);
+  }, 10000);
 });
 


### PR DESCRIPTION
This adds a few tests for functions defined in FlagLoader.js.

There's a test for generating flags for a "firefox39" tree (which doesn't exist, but the flags for it do).

There's a test for generating flags for the "b2g_2_0" tree (which isn't an actual tree, but it's what the flags are called).

There's a test for running the entire FlagLoader.js init function for the "mozilla-b2g32_v2_0" tree (which is what the "b2g_2_0" flags are connected to).

There's a test for running the entire init function for the "mozilla-esr38" tree (which uses the "firefox_esr38" flags).

There's tests for running the entire init function for the "mozilla-central" and "mozilla-aurora" trees (which use version-specific flags based on config files in-tree, requiring network requests to obtain).