### PR TITLE
Bug 1190358: Push footer to the bottom of page when displaying changeset form

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -5,6 +5,12 @@
   src: local('Open sans'), url('opensans.woff');
 }
 
+html, body {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+}
+
 body {
   background: url(../images/sky.png) 0 0 repeat-x rgb(238, 238, 238);
   font-family: Georgia, serif;
@@ -282,6 +288,10 @@ div.ctr {
   z-index: 5;
 }
 
+.grids {
+  padding-bottom: 60px;
+}
+
 .subwarn {
   color: red;
 }
@@ -321,25 +331,24 @@ div.ctr {
   width: 100%;
 }
 
-#footer {
-  width: 900px;
-  margin-left: auto;
-  margin-right: auto;
+#wrapper {
+  min-height: 100%;
+  position: relative;
 }
 
-#footer > div {
-  width: 300px;
+footer {
+  position: absolute;
+  height: 60px;
+  width: 80%;
+  left: 10%;
+  right: 10%;
+  bottom: 0;
+  border-top: 1px solid gray;
+  text-align: center;
 }
 
-#source-link {
-  text-align: left;
-  float: left;
-}
-
-#bugherder-revision {
-  text-align: right;
-  float: right;
-  display: none;
+footer > div {
+  padding: 5px;
 }
 
 .submitButton {
@@ -351,8 +360,13 @@ div.ctr {
   margin-bottom: 10px;
 }
 
-@-moz-document url-prefix(https://mcmerge.paas.allizom.org/) {
-  #bugherder-revision {
-    display: inline !important;
-  }
+#source-link {
+  text-align: left;
+  float: left;
+}
+
+#bugherder-revision {
+  float: right;
+  text-align: right;
+  display: inline !important;
 }

--- a/index.html
+++ b/index.html
@@ -24,144 +24,144 @@
   </head>
   <body>
     <div class="hideAll" id="opaque"></div>
-    <div class="ctr">
-      <h1 id="title">Bugherder</h1>
-      <h4>A tool to help with post-merge Bugzilla administrivia. <a href="http://www.graememcc.co.uk/tag/m-cmerge/">Learn more.</a></h4>
-      <div class="hiddenContent hideAll" id="errors">
-        <span id="errorText"></span>
-      </div>
+    <div id="wrapper">
+      <div class="ctr">
+        <h1 id="title">Bugherder</h1>
+        <h4>A tool to help with post-merge Bugzilla administrivia. <a href="http://www.graememcc.co.uk/tag/m-cmerge/">Learn more.</a></h4>
+        <div class="hiddenContent hideAll" id="errors">
+          <span id="errorText"></span>
+        </div>
 
-      <div class="hiddenContent hideAll" id="loading"></div>
+        <div class="hiddenContent hideAll" id="loading"></div>
 
-      <div class="hiddenContent hideAll" id="getCset">
-        <p id="formText">
-          Please enter the URL or hex changeset ID of a changeset from the merge:
-        </p>
-        <form id="csetForm">
-          <input type="text" id="changeset" autofocus />
-          <input type="submit" value="Submit" id="revSubmit" />
-        </form>
-      </div>
-
-      <div class="hiddenContent hideAll" id="detail"></div>
-
-    </div>
-
-    <div class="wrap">
-      <div class="grids">
-        <div class="hiddenContent hideAll" id="viewerOutput"></div>
-        <div class="hiddenContent hideAll" id="pushes"></div>
-      </div>
-    </div>
-
-    <div class="modal hideAll" id="loadingModal">
-      <div id="lmTitle" class="modalTitle">Loading...</div>
-      <div id="lmContent" class="modalContent">
-        Please wait
-      </div>
-    </div>
-
-    <div class="modal hideAll" id="progressModal">
-      <div id="pmTitle" class="modalTitle">Working...</div>
-      <div id="pmContent" class="modalContent">
-        <div class="ctr"><span id="progressText">0</span>% complete</div>
-        <progress max="100" value="0" id="progressBar">
-        </progress>
-      </div>
-    </div>
-
-    <div class="modal modalForm hideAll" id="addBugModal">
-      <div id="abTitle" class="modalTitle">Add bug</div>
-      <div id="abContent" class="modalContent">
-        <form id="addBugForm">
-          <p>
-           Enter the bug number you wish to add:<br />
-          <input type="text" name="Bug number" id="loadBug" />
+        <div class="hiddenContent hideAll" id="getCset">
+          <p id="formText">
+            Please enter the URL or hex changeset ID of a changeset from the merge:
           </p>
-          <div class="divRight">
-            <input type="submit" value="Add"/>
-            <button id="abCancel">Cancel</button>
-          </div>
-        </form>
-      </div>
-    </div>
+          <form id="csetForm">
+            <input type="text" id="changeset" autofocus />
+            <input type="submit" value="Submit" id="revSubmit" />
+          </form>
+        </div>
 
-    <div class="modal modalForm hideAll" id="changeBugModal">
-      <div id="cbTitle" class="modalTitle">Change bug</div>
-      <div id="cbContent" class="modalContent">
-        <form id="changeBugForm">
-          <p>
-           Enter a new bug number:<br />
-          <input type="text" name="Bug number" id="changeBug" />
-          </p>
-          <div class="divRight">
-            <input type="submit" value="Change"/>
-            <button id="cbCancel">Cancel</button>
-          </div>
-        </form>
-      </div>
-    </div>
+        <div class="hiddenContent hideAll" id="detail"></div>
 
-    <div class="modal modalForm hideAll" id="explanationModal">
-      <div id="exTitle" class="modalTitle">Add explanation for backout</div>
-      <div id="exContent" class="modalContent">
-        <form id="explanationForm">
-          <p>
-           Enter explanatory text for this backout:<br />
-          <textarea name="Bug number" id="explanation"></textarea><br />
-          <label for="useForAll">
-            <input type="checkbox" id="useForAll" checked="checked" />
-            Prepend this text to all remaining backout comments
-          </label>
-          </p>
-          <div class="divRight">
-            <input type="submit" value="OK"/>
-            <button id="exCancel">Cancel</button>
-          </div>
-        </form>
       </div>
-    </div>
 
-    <div class="modal modalForm hideAll" id="credentialsModal">
-      <div id="crTitle" class="modalTitle">Enter your Bugzilla credentials</div>
-      <div id="crContent" class="modalContent">
-        <form id="credentialsForm">
-          <p>Please provide your bugzilla login:<br />
-          Username: <input type="email" name="username" id="username" /><br />
-          Password: <input type="password" name="password" id="password" />
-          </p>
-          <div class="divRight">
-            <input type="submit" value="Submit"/>
-            <button id="crCancel">Cancel</button>
-          </div>
-        </form>
+      <div class="wrap">
+        <div class="grids">
+          <div class="hiddenContent hideAll" id="viewerOutput"></div>
+          <div class="hiddenContent hideAll" id="pushes"></div>
+        </div>
       </div>
-    </div>
 
-    <div class="modal modalForm hideAll" id="messageModal">
-      <div id="mmTitle" class="modalTitle">Whoops!</div>
-      <div id="mmContent" class="modalContent">
-          <p id="mmText">
-          </p>
-          <div class="divRight">
-            <button id="mmOK">OK</button>
-          </div>
+      <div class="modal hideAll" id="loadingModal">
+        <div id="lmTitle" class="modalTitle">Loading...</div>
+        <div id="lmContent" class="modalContent">
+          Please wait
+        </div>
       </div>
-    </div>
 
-    <noscript>
-      You need Javascript to proceed.
-    </noscript>
-
-    <hr />
-
-    <div id="footer">
-      <div id="source-link">
-        <a href="https://github.com/mozilla/Bugherder">Bugherder Source</a>
+      <div class="modal hideAll" id="progressModal">
+        <div id="pmTitle" class="modalTitle">Working...</div>
+        <div id="pmContent" class="modalContent">
+          <div class="ctr"><span id="progressText">0</span>% complete</div>
+          <progress max="100" value="0" id="progressBar">
+          </progress>
+        </div>
       </div>
-      <div id="bugherder-revision">
-        <a href="deploy.txt">Deployed revision</a>
+
+      <div class="modal modalForm hideAll" id="addBugModal">
+        <div id="abTitle" class="modalTitle">Add bug</div>
+        <div id="abContent" class="modalContent">
+          <form id="addBugForm">
+            <p>
+             Enter the bug number you wish to add:<br />
+            <input type="text" name="Bug number" id="loadBug" />
+            </p>
+            <div class="divRight">
+              <input type="submit" value="Add"/>
+              <button id="abCancel">Cancel</button>
+            </div>
+          </form>
+        </div>
       </div>
+
+      <div class="modal modalForm hideAll" id="changeBugModal">
+        <div id="cbTitle" class="modalTitle">Change bug</div>
+        <div id="cbContent" class="modalContent">
+          <form id="changeBugForm">
+            <p>
+             Enter a new bug number:<br />
+            <input type="text" name="Bug number" id="changeBug" />
+            </p>
+            <div class="divRight">
+              <input type="submit" value="Change"/>
+              <button id="cbCancel">Cancel</button>
+            </div>
+          </form>
+        </div>
+      </div>
+
+      <div class="modal modalForm hideAll" id="explanationModal">
+        <div id="exTitle" class="modalTitle">Add explanation for backout</div>
+        <div id="exContent" class="modalContent">
+          <form id="explanationForm">
+            <p>
+             Enter explanatory text for this backout:<br />
+            <textarea name="Bug number" id="explanation"></textarea><br />
+            <label for="useForAll">
+              <input type="checkbox" id="useForAll" checked="checked" />
+              Prepend this text to all remaining backout comments
+            </label>
+            </p>
+            <div class="divRight">
+              <input type="submit" value="OK"/>
+              <button id="exCancel">Cancel</button>
+            </div>
+          </form>
+        </div>
+      </div>
+
+      <div class="modal modalForm hideAll" id="credentialsModal">
+        <div id="crTitle" class="modalTitle">Enter your Bugzilla credentials</div>
+        <div id="crContent" class="modalContent">
+          <form id="credentialsForm">
+            <p>Please provide your bugzilla login:<br />
+            Username: <input type="email" name="username" id="username" /><br />
+            Password: <input type="password" name="password" id="password" />
+            </p>
+            <div class="divRight">
+              <input type="submit" value="Submit"/>
+              <button id="crCancel">Cancel</button>
+            </div>
+          </form>
+        </div>
+      </div>
+
+      <div class="modal modalForm hideAll" id="messageModal">
+        <div id="mmTitle" class="modalTitle">Whoops!</div>
+        <div id="mmContent" class="modalContent">
+            <p id="mmText">
+            </p>
+            <div class="divRight">
+              <button id="mmOK">OK</button>
+            </div>
+        </div>
+      </div>
+
+      <noscript>
+        You need Javascript to proceed.
+      </noscript>
+
+      <footer>
+        <div id="source-link">
+          <a href="https://github.com/mozilla/Bugherder">Bugherder Source</a>
+        </div>
+        <div id="bugherder-revision">
+          <a href="deploy.txt">Deployed revision</a>
+        </div>
+      </footer>
     </div>
   </body>
 </html>


### PR DESCRIPTION
Throws everything in a wrapper div, with enough bottom padding to accomodate the footer, and absolutely positions the footer at the bottom. Also, let's be semantically correct and use the footer tag.