### PR TITLE
Bug 975072 - Allow bugherder to tags comments when marking bugs

### DIFF
--- a/js/PushData.js
+++ b/js/PushData.js
@@ -243,6 +243,22 @@ var PushData = {
     return;
   },
 
+  getTags: function PD_getTags(push) {
+    push.tags = ['bugherder'];
+
+    if (push.isBackout) {
+      push.tags.push('backout');
+    }
+
+    if (push.hgLink.search(/releases\//) >= 0) {
+      push.tags.push('uplift');
+    }
+
+    if (push.hgLink.search(/integration\//) >= 0) {
+      push.tags.push('landing');
+    }
+  },
+
 
   // "Applies" or reverses the effect of the specified backout
   // i.e if reverse is false, it sets the backedOut property on the
@@ -446,6 +462,7 @@ var PushData = {
     // checkIfBackout assumes merges have already been flagged as such
     this.checkIfMerge(push);
     this.checkIfBackout(push);
+    this.getTags(push);
     return push;
   },
 

--- a/js/Step.js
+++ b/js/Step.js
@@ -140,6 +140,7 @@ Step.prototype.createBug = function Step_createBug(bugID, info) {
   if (comments.length > 0) {
     var text = comments.join('\n');
     bug.comment = this.createComment(text);
+    bug.comment_tags = info.tags;
     changed = true;
   }
 
@@ -537,7 +538,8 @@ Step.prototype.attachBugToCset = function Step_attachBugToCset(index, bugID) {
                            canSetStatus: false,
                            shouldSetStatus: false,
                            canSetTestsuite: bug && bug.canSetTestsuite,
-                           milestone: milestone};
+                           milestone: milestone,
+                           tags: PushData.allPushes[index].tags};
 
     // Don't resolve bugs for integration repos
     if (Config.treeName != 'mozilla-central' && Config.treeName != 'comm-central') {


### PR DESCRIPTION
I haven't really tested this much with marking larger pushes, but I believe it does what it's supposed to do. Pushing now and asking for feedback before I forget I already did this work.