### PR TITLE
Switch Heroku and Travis to node v5.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,4 @@ cache:
     - node_modules
 language: node_js
 node_js:
- - "stable"
-
+ - "5.3.0"

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "karma-cli": "*",
     "karma-jasmine": "*",
     "karma-phantomjs-launcher": "*",
-    "karma-chrome-launcher": "~0.2.0"
+    "karma-chrome-launcher": "~0.2.0",
+    "phantomjs": "*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/mozilla/bugherder.git"
   },
   "engines": {
-    "node": "4.2.1"
+    "node": "5.3.0"
   },
   "dependencies": {
     "express": "4.13.3",


### PR DESCRIPTION
Also adds a missing package.json `devDependency` on phantomjs, which would otherwise cause test failures under node v5 (since it ships with npm v3 which is more strict about peer dependencies).