### PR TITLE
Stop clearing the API key field so password managers work

### DIFF
--- a/bugherder/js/UI.js
+++ b/bugherder/js/UI.js
@@ -217,17 +217,14 @@ var UI = {
 
   onCredentialsSubmit: function UI_onCredentialsSubmit(e) {
     ViewerController.onCredentialsEntered($('#apikey').val());
-    $('#apikey').val('');
   },
 
 
   onCredentialsCancel: function UI_onCredentialsCancel(e) {
-    $('#apikey').val('');
   },
 
 
   showCredentialsForm: function UI_showCredentialsForm() {
-    $('#apikey').val('');
     UI.showModalForm('credentialsModal', 'credentialsForm', UI.onCredentialsSubmit,
                      'crCancel', UI.onCredentialsCancel);
     $('#apikey')[0].focus();


### PR DESCRIPTION
I don't understand why the code was clearing username/password/apikey fields but it definitely makes it more painful to use bugherder as it's clearing the data that my password manager fills in.