### PR TITLE
Drop the test for finding a b2g milestone for the current date since there are no such milestones anymore

### DIFF
--- a/test/mySpec.js
+++ b/test/mySpec.js
@@ -113,14 +113,6 @@ describe("A FlagLoader suite", function() {
 });
 
 describe("A ConfigurationData suite", function() {
-  it("should find the correct target milestone for the current date", function() {
-    console.log("starting fxos current date milestone");
-
-    var milestone = ConfigurationData.getDateMilestone();
-    console.log(milestone);
-    expect(milestone).toBeDefined();
-  });
-
   it("should find the correct target milestone for a specific date", function() {
     console.log("starting fxos specific date milestone");
 


### PR DESCRIPTION
This test started failing when we stopped adding new b2g milestones to bugzilla (and in turn to bugherder). I say we just drop it.