### PR TITLE
Some error checking in ConfigurationData.js

### DIFF
--- a/bugherder/js/ConfigurationData.js
+++ b/bugherder/js/ConfigurationData.js
@@ -60,7 +60,7 @@ var ConfigurationData = {
       if (errmsg)
         errorCallback(errmsg);
       else
-        self.parseData(data, loadCallback);
+        self.parseData(data, loadCallback, errorCallback);
     };
 
     var bugzilla = bz.createClient({timeout: 60000});
@@ -68,7 +68,7 @@ var ConfigurationData = {
   },
 
 
-  parseData: function CD_parseData(data, loadCallback) {
+  parseData: function CD_parseData(data, loadCallback, errorCallback) {
     if (!('product' in data)) {
         loadCallback();
         return;
@@ -81,6 +81,9 @@ var ConfigurationData = {
           break;
         }
       }
+    }
+    else {
+      errorCallback("Bugzilla returned invalid configuration data: missing flag_type Array");
     }
     var products = data.product;
     var productMilestones = {}


### PR DESCRIPTION
/bzapi/configuration happened to get stuck sending truncated data today. It would be nice if this particular error was caught by bug herder. This is my suggested change.