### PR TITLE
Bug 1658093 - Add underscore to Thunderbird tracking flag names.

### DIFF
--- a/bugherder/js/FlagLoader.js
+++ b/bugherder/js/FlagLoader.js
@@ -19,7 +19,7 @@ var FlagLoader = {
     var productName = 'firefox';
     var fileLocation = '/browser/config/version.txt';
     if (tree.indexOf('comm') != -1) {
-      productName = 'thunderbird';
+      productName = 'thunderbird_';
       fileLocation = '/mail/config/version.txt';
     }
     var self = this;

--- a/test/mySpec.js
+++ b/test/mySpec.js
@@ -76,6 +76,25 @@ describe("A FlagLoader suite", function() {
 
     FlagLoader.init("510a87909ff5", "mozilla-beta", loadCallback, errorCallback);
   }, 10000);
+
+  it("should init properly for comm-beta", function(done) {
+      console.log("starting comm-beta test");
+
+      results = {
+          tracking: 'tracking_thunderbird_75',
+          status: 'status_thunderbird_75'
+      }
+
+      var loadCallback = function loadCallback(flagData) {
+          console.log(flagData, results);
+          expect(flagData).toEqual(results);
+          done();
+      };
+
+      var errorCallback = function errorCallback(jqResponse, textStatus, errorThrown) {};
+
+      FlagLoader.init("df290067118a", "comm-beta", loadCallback, errorCallback);
+  }, 10000);
 });
 
 describe("A PushData suite", function() {


### PR DESCRIPTION
The tracking and status flags for Thunderbird have an underscore in their
names since Thunderbird 30. The resulting flags are cf_tracking_thunderbird_XX
and cf_status_thunderbird_XX. This is different than the assumption that there
is no underscore as is the case for the Firefox flags.
This sticks the additional underscore in the "productName" variable in FlagLoader
as that variable only gets used to generate the flag names.