### PR TITLE
Bug 1678132 - switch calls fetching bugzilla configuration to REST API. r=RyanVM

### DIFF
--- a/bugherder/thirdparty/bzjs/bz-0.4.3.js
+++ b/bugherder/thirdparty/bzjs/bz-0.4.3.js
@@ -262,7 +262,7 @@ var BugzillaClient = (function () {
       var that = this;
 
       var req = new XMLHttpRequest();
-      req.open('GET', 'https://bugzilla.mozilla.org/latest/configuration?flags=1', true);
+      req.open('GET', 'https://bugzilla.mozilla.org/rest/configuration?flags=1', true);
       req.setRequestHeader("Accept", "application/json");
       req.onreadystatechange = function (event) {
         if (req.readyState == 4 && req.status != 0) {


### PR DESCRIPTION
REST endpoint got added in bug 1622867 and /latest/configuration will be
deprecated.