### PR TITLE
Bug 1970967 - add git revision to bugzilla comment by bugherder

### DIFF
--- a/bugherder/js/Config.js
+++ b/bugherder/js/Config.js
@@ -5,6 +5,7 @@ var Config = {
   inMaintenanceMode : false,
 
   treeName: 'mozilla-central',
+  gitRevURL: "https://github.com/mozilla-firefox/firefox/commit/",
   hgBaseURL: "https://hg.mozilla.org/",
   hgURL: "https://hg.mozilla.org/mozilla-central/",
   hgRevURL: "https://hg.mozilla.org/mozilla-central/rev/",

--- a/bugherder/js/PushData.js
+++ b/bugherder/js/PushData.js
@@ -443,7 +443,9 @@ var PushData = {
   makePush: function PD_makePush(cset) {
     var push = {};
     push.cset = cset.node.substring(0,12);
+    push.cset_git = cset.git_node;
     push.hgLink = Config.hgRevURL + push.cset;
+    push.gitLink = push.cset_git ? Config.gitRevURL + push.cset_git : null;
     // Only use the first line of the commit message, to avoid false
     // positives when checking for bug numbers and backouts later.
     push.desc = UI.htmlEncode(cset.desc.split('\n', 1)[0]);

--- a/bugherder/js/Step.js
+++ b/bugherder/js/Step.js
@@ -492,7 +492,11 @@ Step.prototype.attachBugToCset = function Step_attachBugToCset(index, bugID) {
   var attached = {};
   var isMC = Config.treeName == 'mozilla-central';
 
-  attached.comment = PushData.allPushes[index].hgLink;
+  attached.comment = '';
+  if (PushData.allPushes[index].gitLink) {
+    attached.comment = `${PushData.allPushes[index].gitLink}\n`;
+  }
+  attached.comment += PushData.allPushes[index].hgLink;
 
   if (bugID in BugData.bugs) {
     attached.shouldComment = !(PushData.allPushes[index].backedOut);


### PR DESCRIPTION
The revision and url are identic to the ones for autoland but only posting a Mercurial (hg) revision in a bug can be confusing.